### PR TITLE
Fix bug

### DIFF
--- a/src/MinimuAsyncBridgeUnitTest/UnitTest1.cs
+++ b/src/MinimuAsyncBridgeUnitTest/UnitTest1.cs
@@ -75,17 +75,26 @@ namespace MinimuAsyncBridgeUnitTest
         {
             var t = DateTime.Now;
 
+            var t1 = Task.Delay(10);
+            var t2 = Task.Delay(20);
+            var t3 = Task.Delay(50);
+            var t4 = Task.Delay(100);
+
             await Task.WhenAll(
-                Task.Delay(10),
-                Task.Delay(20),
-                Task.Delay(50),
-                Task.Delay(100));
+                t1,
+                t2,
+                t3,
+                t4);
 
             var elapsed = (DateTime.Now) - t;
 
             // elapsed time is expected to be 100 + some overheads.
-            Assert.IsTrue(elapsed.TotalSeconds >= 100);
-            Assert.IsTrue(elapsed.TotalSeconds < 200);
+            Assert.IsTrue(elapsed.TotalMilliseconds >= 100);
+            Assert.IsTrue(elapsed.TotalMilliseconds < 200);
+            Assert.AreEqual(t1.Status, TaskStatus.RanToCompletion);
+            Assert.AreEqual(t2.Status, TaskStatus.RanToCompletion);
+            Assert.AreEqual(t3.Status, TaskStatus.RanToCompletion);
+            Assert.AreEqual(t4.Status, TaskStatus.RanToCompletion);
         }
 
         private async Task WhenAllForCompletedTask()
@@ -112,23 +121,133 @@ namespace MinimuAsyncBridgeUnitTest
         public void TestWhenAny()
         {
             WhenAnyDelaysShouldAwaitForMinDelay().Wait();
+            WhenAnyDelaysShouldAwaitForMinDelayWithTResult().Wait();
+        }
+
+        [TestMethod]
+        public void WhenAnyShouldBeCanceledIfFirstItemOfTheTasksIsCancled()
+        {
+            WhenAnyShouldBeCanceledIfFirstItemOfTheTasksIsCancledAsync().Wait();
+            WhenAnyShouldBeCanceledIfFirstItemOfTheTasksOfTResultIsCancledAsync().Wait();
+        }
+
+        [TestMethod]
+        public void WhenAnyで最初に例外で終わった場合はResultに例外がでたタスクが返る()
+        {
+            WhenAnyShouldHaveExceptionIfFirstItemOfTheTasksGetErrorAsync().Wait();
+            WhenAnyShouldHaveExceptionIfFirstItemOfTheTasksOfTResultGetErrorAsync().Wait();
+        }
+
+        private async Task WhenAnyShouldBeCanceledIfFirstItemOfTheTasksOfTResultIsCancledAsync()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            Task.Delay(10).ContinueWith(_ => tcs.SetCanceled());
+            var t2 = Task.Delay(500).ContinueWith(_ => 2);
+
+            var r = await Task.WhenAny<int>(tcs.Task, t2);
+
+            Assert.AreSame(r, tcs.Task);
+            Assert.AreEqual(r.Result, default(int));
+        }
+
+        private async Task WhenAnyShouldBeCanceledIfFirstItemOfTheTasksIsCancledAsync()
+        {
+            var tcs = new TaskCompletionSource<object>();
+            Task.Delay(10).ContinueWith(_ => tcs.SetCanceled());
+            var t2 = Task.Delay(500);
+
+            var r = await Task.WhenAny(tcs.Task, t2);
+
+            Assert.AreSame(r, tcs.Task);
+        }
+
+        private async Task WhenAnyShouldHaveExceptionIfFirstItemOfTheTasksOfTResultGetErrorAsync()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            Task.Delay(10).ContinueWith(_ => tcs.SetException(new Exception("planned exception")));
+            var t2 = Task.Delay(500).ContinueWith(_ => 2);
+
+            var r = await Task.WhenAny<int>(tcs.Task, t2);
+
+            Assert.AreSame(r, tcs.Task);
+            Assert.AreEqual(r.Result, default(int));
+        }
+
+        private async Task WhenAnyShouldHaveExceptionIfFirstItemOfTheTasksGetErrorAsync()
+        {
+            var tcs = new TaskCompletionSource<object>();
+            Task.Delay(10).ContinueWith(_ => tcs.SetException(new Exception("planned exception")));
+            var t2 = Task.Delay(500);
+
+            var r = await Task.WhenAny(tcs.Task, t2);
+
+            Assert.AreSame(r, tcs.Task);
+        }
+
+        private async Task WhenAnyDelaysShouldAwaitForMinDelayWithTResult()
+        {
+            var t1 = Task.Delay(10).ContinueWith(_ => 1);
+            var t2 = Task.Delay(20).ContinueWith(_ => 2);
+            var t3 = Task.Delay(50).ContinueWith(_ => 3);
+            var t4 = Task.Delay(100).ContinueWith(_ => 4);
+
+            var r = await Task.WhenAny<int>(
+                t2,
+                t1,
+                t3,
+                t4).ConfigureAwait(false);
+
+            Assert.AreSame(r, t1);
+            Assert.AreEqual(r.Result, 1);
         }
 
         private async Task WhenAnyDelaysShouldAwaitForMinDelay()
         {
-            var t = DateTime.Now;
+            var t1 = Task.Delay(10);
+            var t2 = Task.Delay(20);
+            var t3 = Task.Delay(50);
+            var t4 = Task.Delay(100);
 
-            await Task.WhenAny(
-                Task.Delay(10),
-                Task.Delay(20),
-                Task.Delay(50),
-                Task.Delay(100));
+            var r = await Task.WhenAny(
+                t2,
+                t1,
+                t3,
+                t4).ConfigureAwait(false);
 
-            var elapsed = (DateTime.Now) - t;
+            Assert.AreSame(r, t1);
+        }
 
-            // elapsed time is expected to be 10 + some overheads.
-            Assert.IsTrue(elapsed.TotalSeconds >= 10);
-            Assert.IsTrue(elapsed.TotalSeconds < 30);
+        [TestMethod]
+        public void TestTaskCompletionSource()
+        {
+            TrySetResultShouldWorkIifFirstTime().Wait();
+        }
+
+        private async Task TrySetResultShouldWorkIifFirstTime()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            tcs.TrySetResult(1);
+            tcs.TrySetResult(2);
+
+            var res = await tcs.Task.ConfigureAwait(true);
+            Assert.IsTrue(res == 1);
+        }
+
+        [TestMethod]
+        public void TestCancellationTokenSource()
+        {
+            CancellationTokenSource_CancelShouldWorkIifFirstTime();
+        }
+
+        private void CancellationTokenSource_CancelShouldWorkIifFirstTime()
+        {
+            var cancelCount = 0;
+            var cts = new CancellationTokenSource();
+            cts.Token.Register(() => { cancelCount++; cts.Cancel(); });
+            cts.Cancel();
+
+            Assert.IsTrue(cancelCount == 1);
+
         }
     }
 }

--- a/src/MinimumAsyncBridge/Threading/Tasks/Task`1.cs
+++ b/src/MinimumAsyncBridge/Threading/Tasks/Task`1.cs
@@ -12,8 +12,7 @@ namespace System.Threading.Tasks
 
         internal bool SetResult(TResult result)
         {
-            Result = result;
-            return Complete();
+            return Complete(() => Result = result);
         }
 
         public new TaskAwaiter<TResult> GetAwaiter() => new TaskAwaiter<TResult>(this);

--- a/src/MinimumThreadingBridge/Threading/CancellationTokenSource.cs
+++ b/src/MinimumThreadingBridge/Threading/CancellationTokenSource.cs
@@ -14,12 +14,12 @@
         public void Cancel()
         {
             if (IsCancellationRequested) return;
+            IsCancellationRequested = true;
 
             var d = _canceled;
             if (d != null) d();
             d = null;
 
-            IsCancellationRequested = true;
         }
 
         internal event Action Canceled


### PR DESCRIPTION
- `Task` is not completed if it gets exception or cancels.
- Get an exception when `CancellationTokenSource.Cancel` is called twice or more.
- `Task<TResult>.Result` is overrided when `TaskCompletionSource<TResult>.TrySetResult` is called twice or more.
