### PR TITLE
Task.Delayにキャンセル済みのCancellationTokenを渡した時に nullぽるのを修正。MinimumAsyncBri…

### DIFF
--- a/src/MinimuAsyncBridgeUnitTest/UnitTestTaskDelay.cs
+++ b/src/MinimuAsyncBridgeUnitTest/UnitTestTaskDelay.cs
@@ -48,5 +48,32 @@ namespace MinimuAsyncBridgeUnitTest
 
             Assert.AreEqual(d2.Status, TaskStatus.Canceled);
         }
+
+
+        [TestMethod]
+        public void TaskDelayWithInitiallyCanceledToken()
+        {
+            TaskDelayWithInitiallyCanceledTokenAsync().Wait();
+        }
+
+        private async Task TaskDelayWithInitiallyCanceledTokenAsync()
+        {
+            var cts1 = new CancellationTokenSource();
+            cts1.Cancel();
+            var d1 = Task.Delay(1000, cts1.Token);
+            Assert.AreEqual(d1.Status, TaskStatus.Canceled);
+
+            var exceptionCount = 0;
+            try
+            {
+                await d1;
+            }
+            catch(Exception ex)
+            {
+                Assert.AreEqual(ex.GetType(), typeof(TaskCanceledException));
+                exceptionCount++;
+            }
+            Assert.AreEqual(exceptionCount, 1);
+        }
     }
 }

--- a/src/MinimumAsyncBridge.Nuget/MinimumAsyncBridge.nuspec
+++ b/src/MinimumAsyncBridge.Nuget/MinimumAsyncBridge.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>MinimumAsyncBridge</id>
-    <version>0.9.18.1</version>
+    <version>0.9.18.2</version>
     <title>MinimumAsyncBridge</title>
     <authors>Nobuyuki Iwanaga</authors>
     <owners>Nobuyuki Iwanaga</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/OrangeCube/MinimumAsyncBridge</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Miminum set of the async/await portability libarary.</description>
-    <releaseNotes>Bug fix: Task.Delay.</releaseNotes>
+    <releaseNotes>Bug fix: Task.Delay WithInitiallyCanceledToken.</releaseNotes>
     <copyright>Nobuyuki Iwanaga</copyright>
     <tags>AsyncBridge, async, await</tags>
     <frameworkAssemblies>

--- a/src/MinimumAsyncBridge/Threading/Tasks/Task.cs
+++ b/src/MinimumAsyncBridge/Threading/Tasks/Task.cs
@@ -322,6 +322,12 @@ namespace System.Threading.Tasks
         {
             var tcs = new TaskCompletionSource<bool>();
 
+            if (cancellationToken.IsCancellationRequested)
+            {
+                tcs.SetCanceled();
+                return tcs.Task;
+            }
+
             if (millisecondsDelay <= 0)
             {
                 tcs.SetResult(false);


### PR DESCRIPTION
…dge を 9.18.2 に更新
