### PR TITLE
fix: Task.Delay could throw NRE if delayMilliseconds is 1

### DIFF
--- a/src/MinimuAsyncBridgeUnitTest/UnitTestTaskDelay.cs
+++ b/src/MinimuAsyncBridgeUnitTest/UnitTestTaskDelay.cs
@@ -34,19 +34,42 @@ namespace MinimuAsyncBridgeUnitTest
 
         private async Task TaskDelayCanCancelAsync()
         {
-            var cts1 = new CancellationTokenSource();
-            var d1 = Task.Delay(1000, cts1.Token);
-            cts1.Cancel();
-            Assert.AreEqual(d1.Status, TaskStatus.Canceled);
+            var delays = new[] { 1000, 100, 10, 1 };
 
-            var cts2 = new CancellationTokenSource();
-            var d2 = Task.Delay(1000, cts2.Token);
+            // cancel immediately
+            foreach (var delay in delays)
+            {
+                var cts = new CancellationTokenSource();
+                var d = Task.Delay(delay, cts.Token);
+                cts.Cancel();
+                Assert.AreEqual(TaskStatus.Canceled, d.Status);
+            }
 
-            await Task.Delay(10);
+            var longerDelays = new[] { 1000, 100 };
 
-            cts2.Cancel();
+            foreach (var delay in longerDelays)
+            {
+                var cts = new CancellationTokenSource();
+                var d = Task.Delay(delay, cts.Token);
 
-            Assert.AreEqual(d2.Status, TaskStatus.Canceled);
+                await Task.Delay(10);
+
+                cts.Cancel();
+                Assert.AreEqual(TaskStatus.Canceled, d.Status);
+            }
+
+            var shorterDelays = new[] { 5, 1 };
+
+            foreach (var delay in shorterDelays)
+            {
+                var cts = new CancellationTokenSource();
+                var d = Task.Delay(delay, cts.Token);
+
+                await Task.Delay(100);
+
+                cts.Cancel();
+                Assert.AreEqual(TaskStatus.RanToCompletion, d.Status);
+            }
         }
 
 

--- a/src/MinimumAsyncBridge.Nuget/MinimumAsyncBridge.nuspec
+++ b/src/MinimumAsyncBridge.Nuget/MinimumAsyncBridge.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>MinimumAsyncBridge</id>
-    <version>0.9.19.1</version>
+    <version>0.9.20</version>
     <title>MinimumAsyncBridge</title>
     <authors>Nobuyuki Iwanaga</authors>
     <owners>Nobuyuki Iwanaga</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/OrangeCube/MinimumAsyncBridge</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Miminum set of the async/await portability libarary.</description>
-    <releaseNotes>Bug fix: Task.ContinueWith</releaseNotes>
+    <releaseNotes>Bug fix: Task.Delay could throw NRE if delayMilliseconds is 1</releaseNotes>
     <copyright>Nobuyuki Iwanaga</copyright>
     <tags>AsyncBridge, async, await</tags>
     <frameworkAssemblies>

--- a/src/MinimumAsyncBridge.Nuget/MvvmBridge.nuspec
+++ b/src/MinimumAsyncBridge.Nuget/MvvmBridge.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>MvvmBridge</id>
-    <version>1.0.1.0</version>
+    <version>1.1.0.0</version>
     <title>MvvmBridge</title>
     <authors>Nobuyuki Iwanaga</authors>
     <owners>Nobuyuki Iwanaga</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/OrangeCube/MinimumAsyncBridge</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Miminum set of the MVVM portability libarary.</description>
-    <releaseNotes>Initial release. ObservableCollection, INotifyCollectionChanged</releaseNotes>
+    <releaseNotes>Add caller member info attributes</releaseNotes>
     <copyright>Nobuyuki Iwanaga</copyright>
     <tags>ObservableCollection, INotifyCollectionChanged</tags>
     <frameworkAssemblies>

--- a/src/MvvmBridge.TypeForward/TypeForward.cs
+++ b/src/MvvmBridge.TypeForward/TypeForward.cs
@@ -5,3 +5,6 @@
 [assembly: TypeForwardedTo(typeof(System.Collections.Specialized.NotifyCollectionChangedEventArgs))]
 [assembly: TypeForwardedTo(typeof(System.Collections.Specialized.NotifyCollectionChangedEventHandler))]
 [assembly: TypeForwardedTo(typeof(System.Collections.ObjectModel.ObservableCollection<>))]
+[assembly: TypeForwardedTo(typeof(CallerFilePathAttribute))]
+[assembly: TypeForwardedTo(typeof(CallerLineNumberAttribute))]
+[assembly: TypeForwardedTo(typeof(CallerMemberNameAttribute))]

--- a/src/MvvmBridge/CallerInfoAttributes.cs
+++ b/src/MvvmBridge/CallerInfoAttributes.cs
@@ -1,0 +1,20 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    public sealed class CallerFilePathAttribute : Attribute
+    {
+        public CallerFilePathAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    public sealed class CallerLineNumberAttribute : Attribute
+    {
+        public CallerLineNumberAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    public sealed class CallerMemberNameAttribute : Attribute
+    {
+        public CallerMemberNameAttribute() { }
+    }
+}

--- a/src/MvvmBridge/MvvmBridge.csproj
+++ b/src/MvvmBridge/MvvmBridge.csproj
@@ -38,6 +38,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CallerInfoAttributes.cs" />
     <Compile Include="INotifyCollectionChanged.cs" />
     <Compile Include="NotifyCollectionChangedEventArgs.cs" />
     <Compile Include="ObservableCollection.cs" />


### PR DESCRIPTION
https://github.com/OrangeCube/MinimumAsyncBridge/issues/17
