### PR TITLE
[fix] memory leak in Task.Delay(int, CancellationToken)

### DIFF
--- a/src/MinimuAsyncBridgeUnitTest.V45/MinimuAsyncBridgeUnitTest.V45.csproj
+++ b/src/MinimuAsyncBridgeUnitTest.V45/MinimuAsyncBridgeUnitTest.V45.csproj
@@ -62,6 +62,9 @@
     <Compile Include="..\MinimuAsyncBridgeUnitTest\UnitTestCore.cs">
       <Link>UnitTestCore.cs</Link>
     </Compile>
+    <Compile Include="..\MinimuAsyncBridgeUnitTest\UnitTestMemoryLeak.cs">
+      <Link>UnitTestMemoryLeak.cs</Link>
+    </Compile>
     <Compile Include="..\MinimuAsyncBridgeUnitTest\UnitTestSemaphoreSlim.cs">
       <Link>UnitTestSemaphoreSlim.cs</Link>
     </Compile>

--- a/src/MinimuAsyncBridgeUnitTest/MinimuAsyncBridgeUnitTest.csproj
+++ b/src/MinimuAsyncBridgeUnitTest/MinimuAsyncBridgeUnitTest.csproj
@@ -56,6 +56,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="UnitTestMemoryLeak.cs" />
     <Compile Include="UnitTestSemaphoreSlim.cs" />
     <Compile Include="UnitTestSychronizationContext.cs" />
     <Compile Include="UnitTestTaskCompletionSource.cs" />

--- a/src/MinimuAsyncBridgeUnitTest/UnitTestMemoryLeak.cs
+++ b/src/MinimuAsyncBridgeUnitTest/UnitTestMemoryLeak.cs
@@ -79,11 +79,7 @@ namespace MinimuAsyncBridgeUnitTest
             var cts = new CancellationTokenSource();
             var t = TaskDelay(cts.Token);
             cts.Cancel();
-            try
-            {
-                t.Wait();
-            }
-            catch (OperationCanceledException) { }
+            t.Wait();
             CancellationTokenSourceShouldHaveNoEventListener(cts);
             AllReferencesShouldBeGarbageCollected();
         }
@@ -104,7 +100,11 @@ namespace MinimuAsyncBridgeUnitTest
             {
                 var t = Task.Delay(1, ct);
                 Add(t);
-                await t;
+                try
+                {
+                    await t;
+                }
+                catch (OperationCanceledException) { }
             }
         }
     }

--- a/src/MinimuAsyncBridgeUnitTest/UnitTestMemoryLeak.cs
+++ b/src/MinimuAsyncBridgeUnitTest/UnitTestMemoryLeak.cs
@@ -1,0 +1,111 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using static System.Reflection.BindingFlags;
+
+namespace MinimuAsyncBridgeUnitTest
+{
+    [TestClass]
+    public class UnitTestMemoryLeak
+    {
+        List<WeakReference> _refs = new List<WeakReference>();
+
+        void Add<T>(T item)
+        {
+            lock (_refs)
+            {
+                _refs.Add(new WeakReference(item));
+            }
+        }
+
+        void AllReferencesShouldBeGarbageCollected()
+        {
+            GC.Collect(2, GCCollectionMode.Forced);
+
+            lock(_refs)
+            {
+                foreach (var r in _refs)
+                    Assert.IsNull(r.Target);
+                _refs.Clear();
+            }
+        }
+
+        [System.Diagnostics.Conditional("V35")]
+        private static void CancellationTokenSourceShouldHaveNoEventListener(CancellationTokenSource cts)
+        {
+            var f = cts.GetType().GetField("_canceled", NonPublic | Instance);
+            var v = f.GetValue(cts);
+            Assert.IsNull(v);
+        }
+
+        [TestMethod]
+        public void TestTaskRun()
+        {
+            TaskRun().Wait();
+            AllReferencesShouldBeGarbageCollected();
+        }
+
+        async Task TaskRun()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                var t = Task.Run(() => { });
+                Add(t);
+                await t;
+            }
+        }
+
+        [TestMethod]
+        public void TestTaskDelay()
+        {
+            TaskDelay().Wait();
+            AllReferencesShouldBeGarbageCollected();
+        }
+
+        [TestMethod]
+        public void TestTaskDelayWithoutCancel()
+        {
+            var cts = new CancellationTokenSource();
+            TaskDelay(cts.Token).Wait();
+            CancellationTokenSourceShouldHaveNoEventListener(cts);
+            AllReferencesShouldBeGarbageCollected();
+        }
+
+        [TestMethod]
+        public void TestTaskDelayWithCancel()
+        {
+            var cts = new CancellationTokenSource();
+            var t = TaskDelay(cts.Token);
+            cts.Cancel();
+            try
+            {
+                t.Wait();
+            }
+            catch (OperationCanceledException) { }
+            CancellationTokenSourceShouldHaveNoEventListener(cts);
+            AllReferencesShouldBeGarbageCollected();
+        }
+
+        async Task TaskDelay()
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                var t = Task.Delay(1);
+                Add(t);
+                await t;
+            }
+        }
+
+        async Task TaskDelay(CancellationToken ct)
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                var t = Task.Delay(1, ct);
+                Add(t);
+                await t;
+            }
+        }
+    }
+}

--- a/src/MinimumAsyncBridge.Nuget/MinimumAsyncBridge.nuspec
+++ b/src/MinimumAsyncBridge.Nuget/MinimumAsyncBridge.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>MinimumAsyncBridge</id>
-    <version>0.9.25</version>
+    <version>0.9.26</version>
     <title>MinimumAsyncBridge</title>
     <authors>Nobuyuki Iwanaga</authors>
     <owners>Nobuyuki Iwanaga</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/OrangeCube/MinimumAsyncBridge</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Miminum set of the async/await portability libarary.</description>
-    <releaseNotes>fix bug on SemaphoreSlim</releaseNotes>
+    <releaseNotes>fix memory leak in Task.Delay(int, CancellationToken)</releaseNotes>
     <copyright>Nobuyuki Iwanaga</copyright>
     <tags>AsyncBridge, async, await</tags>
     <frameworkAssemblies>

--- a/src/MinimumAsyncBridge.Nuget/MinimumAsyncBridge.nuspec
+++ b/src/MinimumAsyncBridge.Nuget/MinimumAsyncBridge.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>MinimumAsyncBridge</id>
-    <version>0.9.26</version>
+    <version>0.9.26.1</version>
     <title>MinimumAsyncBridge</title>
     <authors>Nobuyuki Iwanaga</authors>
     <owners>Nobuyuki Iwanaga</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/OrangeCube/MinimumAsyncBridge</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Miminum set of the async/await portability libarary.</description>
-    <releaseNotes>fix memory leak in Task.Delay(int, CancellationToken)</releaseNotes>
+    <releaseNotes>fix memory leak in SemaphoreSlim.WaitAsync(CancellationToken)</releaseNotes>
     <copyright>Nobuyuki Iwanaga</copyright>
     <tags>AsyncBridge, async, await</tags>
     <frameworkAssemblies>

--- a/src/MinimumAsyncBridge.Nuget/MinimumThreadingBridge.nuspec
+++ b/src/MinimumAsyncBridge.Nuget/MinimumThreadingBridge.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>MinimumThreadingBridge</id>
-    <version>0.9.8.0</version>
+    <version>0.9.8.1</version>
     <title>MinimumThreadingBridge</title>
     <authors>Nobuyuki Iwanaga</authors>
     <owners>Nobuyuki Iwanaga</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/OrangeCube/MinimumAsyncBridge</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Miminum set of the async/await portability libarary.</description>
-    <releaseNotes>CancellationTokenRegistration</releaseNotes>
+    <releaseNotes>allows CancellationToken.Register(...).Dispose()</releaseNotes>
     <copyright>Nobuyuki Iwanaga</copyright>
     <tags>AsyncBridge, CancellationToken</tags>
     <frameworkAssemblies>

--- a/src/MinimumAsyncBridge/Threading/SemaphoreSlim.cs
+++ b/src/MinimumAsyncBridge/Threading/SemaphoreSlim.cs
@@ -26,6 +26,7 @@
         class TaskNode : TaskCompletionSource<bool>
         {
             public TaskNode Next;
+            public CancellationTokenRegistration Cancelation;
         }
 
         public Task WaitAsync() => WaitAsync(CancellationToken.None);
@@ -53,7 +54,14 @@
                     }
 
                     if (cancellationToken != CancellationToken.None)
-                        cancellationToken.Register(() => task.TrySetCanceled());
+                    {
+                        task.Cancelation = cancellationToken.Register(() =>
+                        {
+                            task.TrySetCanceled();
+                            if (task.Cancelation != default(CancellationTokenRegistration))
+                                task.Cancelation.Dispose();
+                        });
+                    }
 
                     return task.Task;
                 }
@@ -94,6 +102,8 @@
 
             if (head != null)
             {
+                if (head.Cancelation != default(CancellationTokenRegistration))
+                    head.Cancelation.Dispose();
                 Task.Run(() => head.TrySetResult(false));
             }
 

--- a/src/MinimumAsyncBridge/Threading/SemaphoreSlim.cs
+++ b/src/MinimumAsyncBridge/Threading/SemaphoreSlim.cs
@@ -26,7 +26,7 @@
         class TaskNode : TaskCompletionSource<bool>
         {
             public TaskNode Next;
-            public CancellationTokenRegistration Cancelation;
+            public CancellationTokenRegistration Cancellation;
         }
 
         public Task WaitAsync() => WaitAsync(CancellationToken.None);
@@ -55,11 +55,11 @@
 
                     if (cancellationToken != CancellationToken.None)
                     {
-                        task.Cancelation = cancellationToken.Register(() =>
+                        task.Cancellation = cancellationToken.Register(() =>
                         {
                             task.TrySetCanceled();
-                            if (task.Cancelation != default(CancellationTokenRegistration))
-                                task.Cancelation.Dispose();
+                            if (task.Cancellation != default(CancellationTokenRegistration))
+                                task.Cancellation.Dispose();
                         });
                     }
 
@@ -102,8 +102,8 @@
 
             if (head != null)
             {
-                if (head.Cancelation != default(CancellationTokenRegistration))
-                    head.Cancelation.Dispose();
+                if (head.Cancellation != default(CancellationTokenRegistration))
+                    head.Cancellation.Dispose();
                 Task.Run(() => head.TrySetResult(false));
             }
 

--- a/src/MinimumThreadingBridge/Threading/CancellationTokenRegistration.cs
+++ b/src/MinimumThreadingBridge/Threading/CancellationTokenRegistration.cs
@@ -13,7 +13,8 @@
 
         public void Dispose()
         {
-            _source.Canceled -= _callback;
+            if (_source != null)
+                _source.Canceled -= _callback;
         }
         public bool Equals(CancellationTokenRegistration other) => _source == other._source && _callback == other._callback;
         public override bool Equals(object obj) => obj is CancellationTokenRegistration && Equals((CancellationTokenRegistration)obj);

--- a/src/MinimumThreadingBridge/Threading/CancellationTokenSource.cs
+++ b/src/MinimumThreadingBridge/Threading/CancellationTokenSource.cs
@@ -1,6 +1,6 @@
 ﻿namespace System.Threading
 {
-    public class CancellationTokenSource
+    public class CancellationTokenSource : IDisposable
     {
         public CancellationTokenSource()
         {
@@ -57,6 +57,11 @@
                 Cancel();
                 t = null;
             }, null, millisecondsDelay, Timeout.Infinite);
+        }
+
+        public void Dispose()
+        {
+            _canceled = null;
         }
     }
 }


### PR DESCRIPTION
Thre was a memory leak in Task.Delay(int, CancellationToken) if you
didn't call CancellationTokenSource.Cancel.
