### PR TITLE
Skip unmanaged module at LayoutAutoToSequencial

### DIFF
--- a/tools/LayoutAutoToSequencial/Program.cs
+++ b/tools/LayoutAutoToSequencial/Program.cs
@@ -68,7 +68,16 @@ namespace LayoutAutoToSequencial
         /// <param name="file"></param>
         private static void RewriteDll(string file)
         {
-            var module = ModuleDefinition.ReadModule(file);
+            ModuleDefinition module;
+            try
+            {
+                module = ModuleDefinition.ReadModule(file);
+            }
+            catch (BadImageFormatException)
+            {
+                // Skip unmanaged module
+                return;
+            }
 
             var types = GetAllTypes(module);
             var any = false;


### PR DESCRIPTION
Threw BadImageFormatException when unmanaged dll.
```cs
System.BadImageFormatException: Format of the executable (.exe) or library (.dll) is invalid.
   at Mono.Cecil.PE.ImageReader.ReadOptionalHeaders(UInt16& subsystem, UInt16& dll_characteristics)
   at Mono.Cecil.PE.ImageReader.ReadImage()
   at Mono.Cecil.PE.ImageReader.ReadImageFrom(Stream stream)
   at Mono.Cecil.ModuleDefinition.ReadModule(Stream stream, ReaderParameters parameters)
   at Mono.Cecil.ModuleDefinition.ReadModule(String fileName, ReaderParameters parameters)
   at LayoutAutoToSequencial.Program.RewriteDll(String file)
   at LayoutAutoToSequencial.Program.Main(String[] args)
```