### PR TITLE
update ST.Tasks.Extensions PackageReference to 4.5

### DIFF
--- a/src/TasksExtensions/TasksExtensionsBridge.TypeForward/TasksExtensionsBridge.TypeForward.csproj
+++ b/src/TasksExtensions/TasksExtensionsBridge.TypeForward/TasksExtensionsBridge.TypeForward.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/TasksExtensions/TasksExtensionsBridge.TypeForward/TypeForward.cs
+++ b/src/TasksExtensions/TasksExtensionsBridge.TypeForward/TypeForward.cs
@@ -1,8 +1,13 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
+[assembly: TypeForwardedTo(typeof(ValueTask))]
 [assembly: TypeForwardedTo(typeof(ValueTask<>))]
+[assembly: TypeForwardedTo(typeof(ValueTaskAwaiter))]
 [assembly: TypeForwardedTo(typeof(ValueTaskAwaiter<>))]
+[assembly: TypeForwardedTo(typeof(ConfiguredValueTaskAwaitable))]
 [assembly: TypeForwardedTo(typeof(ConfiguredValueTaskAwaitable<>))]
+[assembly: TypeForwardedTo(typeof(AsyncValueTaskMethodBuilder))]
 [assembly: TypeForwardedTo(typeof(AsyncValueTaskMethodBuilder<>))]
 [assembly: TypeForwardedTo(typeof(AsyncMethodBuilderAttribute))]
+[assembly: TypeForwardedTo(typeof(System.Threading.Tasks.Sources.IValueTaskSource))]

--- a/src/nuspecs/TasksExtensionsBridge.nuspec
+++ b/src/nuspecs/TasksExtensionsBridge.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>TasksExtensionsBridge</id>
-    <version>0.1.4</version>
+    <version>0.2.0</version>
     <title>TasksExtensionsBridge</title>
     <authors>Nobuyuki Iwanaga</authors>
     <owners>Nobuyuki Iwanaga</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/OrangeCube/MinimumAsyncBridge</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Backporting of System.Threading.Tasks.Extensions for .NET 3.5.</description>
-    <releaseNotes>update MinimumAsyncBridge to 0.11.1</releaseNotes>
+    <releaseNotes>Support non-generic ValueTask.</releaseNotes>
     <copyright>Nobuyuki Iwanaga</copyright>
     <tags>Tasks.Extensions</tags>
     <frameworkAssemblies>
@@ -21,10 +21,10 @@
         <dependency id="MinimumAsyncBridge" version="0.11.1" />
       </group>
       <group targetFramework="net45">
-        <dependency id="System.Threading.Tasks.Extensions" version="4.3" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5" />
       </group>
       <group targetFramework="netstandard1.0">
-        <dependency id="System.Threading.Tasks.Extensions" version="4.3" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
support non-generic ValueTask.